### PR TITLE
Check authentication system integrity

### DIFF
--- a/backend/app/routes/stages/discover/visual_guide_routes.py
+++ b/backend/app/routes/stages/discover/visual_guide_routes.py
@@ -7,10 +7,12 @@ try:
     from app.routes.upload import download_blob_to_tmp
 except Exception:
     download_blob_to_tmp = None
+from flask_jwt_extended import jwt_required, get_jwt_identity
 
 vsg_bp = Blueprint("study_guide", __name__)
 
 @vsg_bp.route("/generate_visual_study_guide", methods=["POST"])
+@jwt_required()
 def generate_visual_study_guide():
     """
     Accepts:
@@ -69,7 +71,7 @@ def generate_visual_study_guide():
                 if from_vault and filename:
                     if not download_blob_to_tmp:
                         return jsonify({"error": "Vault download not available on server"}), 500
-                    tmp_path = download_blob_to_tmp(filename)
+                    tmp_path = download_blob_to_tmp(filename, user_id=get_jwt_identity())
                     current_app.logger.info(f"[VSG] Vault file downloaded to: {tmp_path}")
                     return jsonify(svc.from_document(tmp_path)), 200
 

--- a/backend/app/routes/upload.py
+++ b/backend/app/routes/upload.py
@@ -1,6 +1,6 @@
 import tempfile, uuid, os
 # upload.py
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, has_request_context
 from azure.storage.blob import BlobServiceClient, ContentSettings
 from werkzeug.utils import secure_filename
 from datetime import datetime
@@ -10,6 +10,7 @@ from app.models.files import UploadedFile
 from app.db import db
 import logging
 from urllib.parse import urlparse
+from flask_jwt_extended import jwt_required, get_jwt_identity
 
 upload_bp = Blueprint('upload', __name__)
 
@@ -27,6 +28,7 @@ def get_current_user_id():
     return "admin"
 
 @upload_bp.route('/upload', methods=['POST'])
+@jwt_required()
 def upload_file():
     if 'file' not in request.files:
         return jsonify({'error': 'No file part in request'}), 400
@@ -35,7 +37,7 @@ def upload_file():
     if file.filename == '':
         return jsonify({'error': 'No selected file'}), 400
 
-    user_id = get_current_user_id()
+    user_id = get_jwt_identity()
     filename = secure_filename(file.filename)
     timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
     unique_filename = f"{timestamp}_{uuid.uuid4().hex}_{filename}"
@@ -80,8 +82,9 @@ def upload_file():
     
 
 @upload_bp.route('/files', methods=['GET'])
+@jwt_required()
 def list_files():
-    user_id = get_current_user_id()
+    user_id = get_jwt_identity()
     prefix = f"{user_id}/uploads/"
 
     try:
@@ -112,19 +115,36 @@ def list_files():
         return jsonify({ "error": str(e) }), 500
 
 
-def download_blob_to_tmp(filename_or_url):
-    user_id = get_current_user_id()
-
+def download_blob_to_tmp(filename_or_url, user_id: str = None):
     # Extract stored filename safely
     parsed = urlparse(filename_or_url)
     stored_filename = os.path.basename(parsed.path) if parsed.scheme else filename_or_url
+
+    # Resolve user_id from request JWT if available
+    if user_id is None and has_request_context():
+        try:
+            user_id = get_jwt_identity()
+        except Exception:
+            user_id = None
+
+    # Fallback: resolve user_id from DB by stored filename
+    if not user_id:
+        try:
+            rec = UploadedFile.query.filter_by(stored_file_name=stored_filename).first()
+            if rec:
+                user_id = rec.user_id
+        except Exception:
+            pass
+
+    if not user_id:
+        raise RuntimeError("Unable to determine user_id for vault download")
 
     blob_path = f"{user_id}/uploads/{stored_filename}"
 
     blob_service_client = BlobServiceClient.from_connection_string(AZURE_STORAGE_CONNECTION_STRING)
     blob_client = blob_service_client.get_blob_client(container=CONTAINER_NAME, blob=blob_path)
 
-    tmp_path = os.path.join("/tmp", stored_filename)  # ✅ Only actual filename, no full URL
+    tmp_path = os.path.join("/tmp", stored_filename)
     logger.info(f"Downloading blob to temporary path: {tmp_path}")
 
     with open(tmp_path, "wb") as f:

--- a/backend/app/stages/discover/interactive_timeline_explorer/timeline_explorer_routes.py
+++ b/backend/app/stages/discover/interactive_timeline_explorer/timeline_explorer_routes.py
@@ -9,6 +9,7 @@ from app.routes.upload import download_blob_to_tmp  # <- Make sure you have this
 import os
 import logging
 import tempfile
+from flask_jwt_extended import jwt_required, get_jwt_identity
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ def handle_file_upload(file):
     return file_path
 
 @timeline_explorer_bp.route('/generate_timeline', methods=['POST'])
+@jwt_required()
 def generate_timeline():
     file_path = None
 
@@ -45,7 +47,7 @@ def generate_timeline():
                         logger.info("Missing filename for vault-based timeline generation")
                         return jsonify({"error": "Missing filename for vault-based timeline generation"}), 400
 
-                    file_path = download_blob_to_tmp(filename)
+                    file_path = download_blob_to_tmp(filename, user_id=get_jwt_identity())
                     logger.info(f"Vault file downloaded to: {file_path}")
                 else:
                     logger.info("Expected file upload or fromVault=True in JSON")

--- a/backend/app/stages/discover/math_problem_visualizer/math_problem_visualizer_routes.py
+++ b/backend/app/stages/discover/math_problem_visualizer/math_problem_visualizer_routes.py
@@ -10,10 +10,12 @@ from app.utils.file_utils import (
     extract_text_from_audio,
     extract_text_from_video
 )
+from flask_jwt_extended import jwt_required, get_jwt_identity
 logger = logging.getLogger(__name__)
 math_problem_visualiser_bp = Blueprint('math_problem_visualiser', __name__)
 
 @math_problem_visualiser_bp.route('/visualize_math_problem', methods=['POST'])
+@jwt_required()
 def visualize_math_problem():
     """
     Handles visualization of math problems from:
@@ -35,7 +37,7 @@ def visualize_math_problem():
             from_vault = data.get('fromVault', False)
             if from_vault and filename:
                 logger.info(f"Fetching from vault: {filename}")
-                filepath = download_blob_to_tmp(filename)
+                filepath = download_blob_to_tmp(filename, user_id=get_jwt_identity())
                 problem_text = extract_text_from_document(filepath)
 
         # If multipart (file upload)

--- a/backend/app/stages/discover/summarizer/summarizer_routes.py
+++ b/backend/app/stages/discover/summarizer/summarizer_routes.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 from app.utils.file_utils import extract_text_by_pages
 from math import ceil
 from app.models import Progress
+from flask_jwt_extended import jwt_required, get_jwt_identity
 
 
 # Configure logger
@@ -36,6 +37,7 @@ def summarize_text_route():
 
 
 @summarizer_bp.route('/summarize_file', methods=['POST'])
+@jwt_required()
 def summarize_file_route():
     try:
         # 1. Extract file
@@ -46,7 +48,7 @@ def summarize_file_route():
             from_vault = data.get('fromVault', False)
             if not filename or not from_vault:
                 return jsonify({"error": "Missing filename or vault flag"}), 400
-            file_path = download_blob_to_tmp(filename)
+            file_path = download_blob_to_tmp(filename, user_id=get_jwt_identity())
 
         elif 'file' in request.files:
             file = request.files['file']

--- a/backend/app/tasks/timeline_explorer_tasks.py
+++ b/backend/app/tasks/timeline_explorer_tasks.py
@@ -45,7 +45,7 @@ def build_timeline(self, progress_id: str, method: str, payload: dict):
             prog.percentage = 100
         elif method == "document":
             if payload.get("fromVault") and download_blob_to_tmp:
-                tmp_path = download_blob_to_tmp(payload.get("filename"))
+                tmp_path = download_blob_to_tmp(payload.get("filename"), user_id=str(prog.user_id))
                 prog.percentage = 20; s.commit()
                 out = svc.from_document(tmp_path)
                 prog.percentage = 100


### PR DESCRIPTION
Harden `download_blob_to_tmp` and protect routes to fix JWT context errors and ensure user-scoped file access.

The `RuntimeError` occurred because `get_jwt_identity()` was invoked in contexts lacking JWT (e.g., Celery tasks or unauthenticated routes), leading to crashes. This PR ensures `user_id` is always available, either from the JWT context (when present) or via a database lookup, and protects relevant routes.

---
<a href="https://cursor.com/background-agent?bcId=bc-d494483f-5f82-4214-b60a-3ca0df15170c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d494483f-5f82-4214-b60a-3ca0df15170c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

